### PR TITLE
Update CS8 nodejs module to nodejs:14

### DIFF
--- a/Dockerfile.stream8
+++ b/Dockerfile.stream8
@@ -3,8 +3,12 @@ FROM quay.io/centos/centos:stream8
 # Install oVirt repositories
 RUN dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
     && dnf install -y ovirt-release-master
-# Configure CS8 repositories
-RUN dnf module enable -y pki-deps javapackages-tools
+
+# Configure CS8 modules
+RUN dnf module enable -y \
+    pki-deps \
+    javapackages-tools \
+    nodejs:14
 
 # Install required packages
 RUN dnf install -y \


### PR DESCRIPTION
## Changes introduced with this PR

Update CS8 modules
  - el8 (centos:stream8) by default uses nodejs:10
  - ovirt-web-ui and ovirt-engine-ui-extensions need at least nodejs:14

## Are you the owner of the code you are sending in, or do you have permission of the owner?
y
