### PR TITLE
Add GitHub CLI to the build containers

### DIFF
--- a/Dockerfile.stream8
+++ b/Dockerfile.stream8
@@ -10,6 +10,12 @@ RUN dnf module enable -y \
     javapackages-tools \
     nodejs:14
 
+# Install the GitHub CLI so actions can use it when running in the container
+RUN \
+    dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
+    && dnf -y install gh \
+    && dnf clean all
+
 # Install required packages
 RUN dnf install -y \
         createrepo_c \

--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -10,6 +10,12 @@ RUN dnf copr enable -y ovirt/ovirt-master-snapshot \
 # Configure CS9 repositories
 RUN dnf config-manager --enable crb
 
+# Install the GitHub CLI so actions can use it when running in the container
+RUN \
+    dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
+    && dnf -y install gh \
+    && dnf clean all
+
 # Install required packages
 RUN dnf install -y \
         createrepo_c \


### PR DESCRIPTION
## Changes introduced with this PR

Normal github build runners have the github cli [installed by default](https://docs.github.com/en/actions/advanced-guides/using-github-cli-in-workflows). To use this the workflows running on the ovirt build containers, it needs to be installed.

Two cases where it is very useful to have the github cli available:

  1. Checking out a PR from a `on: issue_comment` workflow.  The base checkout action will checkout the main/master branch in this case. The PR needs to be explicitly checkout out.  Example: https://github.com/oVirt/ovirt-engine-nodejs-modules/blob/b36e174c0ba7ae1beeec9b604a87af01ef5b3f66/.github/workflows/comment-to-build-pr.yaml#L33-L40

  2. Posting a comment to a PR with a link to a workflow run's summary page.  Example: https://github.com/oVirt/ovirt-engine-nodejs-modules/blob/b36e174c0ba7ae1beeec9b604a87af01ef5b3f66/.github/workflows/comment-to-build-pr.yaml#L60-L71


## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes