### PR TITLE
add ost-images dependecies on el9stream

### DIFF
--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -47,3 +47,14 @@ RUN dnf install -y \
     virt-install \
     && \
     dnf clean all
+
+# Install dependencies for ost-images that we do not ship
+# Only on EL9
+RUN gh repo clone oVirt/ost-images \
+    && cd ost-images \
+    &&  autoreconf -i \
+    && ./configure \
+    && make spec \
+    && dnf builddep -y ost-images.spec \
+    && cd .. \
+    && rm -rf ost-images

--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -49,8 +49,9 @@ RUN dnf install -y \
     dnf clean all
 
 # Install dependencies for ost-images that we do not ship
-# Only on EL9
-RUN gh repo clone oVirt/ost-images \
+# Only on el9 since el8 container is not usable on el9 host
+# The resulting images are independent of build platform
+RUN git clone https://github.com/oVirt/ost-images.git \
     && cd ost-images \
     && autoreconf -i \
     && ./configure \

--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -52,9 +52,10 @@ RUN dnf install -y \
 # Only on EL9
 RUN gh repo clone oVirt/ost-images \
     && cd ost-images \
-    &&  autoreconf -i \
+    && autoreconf -i \
     && ./configure \
     && make spec \
     && dnf builddep -y ost-images.spec \
     && cd .. \
-    && rm -rf ost-images
+    && rm -rf ost-images \
+    && dnf clean all


### PR DESCRIPTION
it would be handy to use the container for building ost-images on
el9stream builders. We do not ship this package so we need to get the
build deps from sources

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]