### PR TITLE
use legacy crypto policy on el9

### DIFF
--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -3,6 +3,13 @@ FROM quay.io/centos/centos:stream9
 # DNF core plugins are installed in the official CS9 container image
 RUN dnf install -y dnf-plugins-core
 
+# Ensure crypto policies are installed
+RUN dnf install -y crypto-policies-scripts crypto-policies
+
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN update-crypto-policies --set LEGACY
+
 # Install oVirt repositories
 RUN dnf copr enable -y ovirt/ovirt-master-snapshot \
     && dnf install -y ovirt-release-master


### PR DESCRIPTION
Fixes issue #11

## Changes introduced with this PR

Recent openssl dropped support for sha1 algo but COPR and several
other packaging systems are still signing RPMS with sha1.
In order to be able to install RPMs switching from default crypto policy
to legacy one untill RPMS with newer sha signature will be provided.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes