### PR TITLE
containers: Specify COPR chroot explicitly

### DIFF
--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -11,7 +11,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies
 RUN update-crypto-policies --set LEGACY
 
 # Install oVirt repositories
-RUN dnf copr enable -y ovirt/ovirt-master-snapshot \
+RUN dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && dnf install -y ovirt-release-master
 
 # Configure CS9 repositories


### PR DESCRIPTION
A recent change to DNF COPR plugin [1] makes 'epel-9' the default chroot
used for CentOS Stream 9. Let's specify the 'centos-stream-9' chroot
name that we use in oVirt's COPR explictly.

[1] https://github.com/rpm-software-management/dnf-plugins-core/pull/459

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
