### PR TITLE
use generic distro names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: centos-stream-8
-            shortcut: cs8
+          - name: el8
             container-name: el8stream
-          - name: centos-stream-9
-            shortcut: cs9
+          - name: el9
             container-name: el9stream
     name: ${{ matrix.name }}
     container:


### PR DESCRIPTION
we may eventually use different distro than CentOS Stream, let's use generic naming elX
