### PR TITLE
Install dnf-plugins-core in stream8 build

### DIFF
--- a/Dockerfile.stream8
+++ b/Dockerfile.stream8
@@ -1,5 +1,8 @@
 FROM quay.io/centos/centos:stream8
 
+# Install DNF core plugins
+RUN dnf install -y dnf-plugins-core
+
 # Install oVirt repositories
 RUN dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
     && dnf install -y ovirt-release-master

--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-# DNF core plugins are installed in the official CS9 container image
+# Install DNF core plugins
 RUN dnf install -y dnf-plugins-core
 
 # Ensure crypto policies are installed


### PR DESCRIPTION
This fixes error on creating the image as otherwise the 'dnf copr' command does not work without the dnf-plugins-core installed.